### PR TITLE
fix: wrong env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,7 @@ services:
       SOCKETIO_PORT: "9000"
       AI_HUB_URL : ${AI_HUB_URL}
       AI_HUB_ACCESS_TOKEN: ${AI_HUB_ACCESS_TOKEN}
-      AI_HUB_WEBHOOK: ${AI_HUB_ACCESS_TOKEN}
+      AI_HUB_WEBHOOK: ${AI_HUB_WEBHOOK}
     volumes:
       - sites:/home/frappe/frappe-bench/sites
       - logs:/home/frappe/frappe-bench/logs


### PR DESCRIPTION
### **PR Type**
bug_fix, enhancement


___

### **Description**
- Corrects environment variable for `AI_HUB_WEBHOOK` in Docker Compose.

- Ensures proper webhook configuration using `${AI_HUB_WEBHOOK}`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yml</strong><dd><code>Correct AI_HUB_WEBHOOK environment variable assignment</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose.yml

<li>Replaces incorrect <code>AI_HUB_WEBHOOK</code> assignment.<br> <li> Uses <code>${AI_HUB_WEBHOOK}</code> instead of <code>${AI_HUB_ACCESS_TOKEN}</code>.<br> <li> Ensures correct environment variable is passed to the service.


</details>


  </td>
  <td><a href="https://github.com/jemmia-diamond/erp/pull/12/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>